### PR TITLE
Tallenetaan notifications valinta, ja notifikaatioiden poisto toimii

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="18" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "fi.jesunmaailma.fooder.android"
         minSdk 21
         targetSdk 33
-        versionCode 20220924
-        versionName "2022.9.24"
+        versionCode 20220925
+        versionName "2022.9.25"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/fi/jesunmaailma/fooder/android/ui/activities/Profile.java
+++ b/app/src/main/java/fi/jesunmaailma/fooder/android/ui/activities/Profile.java
@@ -75,6 +75,7 @@ public class Profile extends AppCompatActivity {
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_profile);
+        swNotifications = findViewById(R.id.sw_notifications);
 
         toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -94,7 +95,6 @@ public class Profile extends AppCompatActivity {
         btnEditName = findViewById(R.id.btn_edit_name);
         btnEditPassword = findViewById(R.id.btn_edit_password);
         btnDeleteAccount = findViewById(R.id.btn_delete_account);
-        swNotifications = findViewById(R.id.sw_notifications);
 
         client = GoogleSignIn.getClient(Profile.this, GoogleSignInOptions.DEFAULT_SIGN_IN);
 

--- a/app/src/main/java/fi/jesunmaailma/fooder/android/ui/activities/Profile.java
+++ b/app/src/main/java/fi/jesunmaailma/fooder/android/ui/activities/Profile.java
@@ -1,8 +1,10 @@
 package fi.jesunmaailma.fooder.android.ui.activities;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -13,6 +15,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -42,6 +45,7 @@ import org.json.JSONObject;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import fi.jesunmaailma.fooder.android.R;
 import fi.jesunmaailma.fooder.android.services.FooderDataService;
@@ -57,11 +61,10 @@ public class Profile extends AppCompatActivity {
     FirebaseUser user;
     FirebaseAnalytics analytics;
     DocumentReference documentReference;
-
     GoogleSignInClient client;
-
     ActionBar actionBar;
     Toolbar toolbar;
+    boolean notificationsEnabled = false;
     SwitchMaterial swNotifications;
     LayoutInflater inflater;
 
@@ -75,6 +78,8 @@ public class Profile extends AppCompatActivity {
 
         toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        SharedPreferences sharedPref = getPreferences(Context.MODE_PRIVATE);
+        notificationsEnabled = sharedPref.getBoolean("notification",false);
 
         actionBar = getSupportActionBar();
 
@@ -121,6 +126,8 @@ public class Profile extends AppCompatActivity {
             btnEditPassword.setVisibility(View.GONE);
             btnDeleteAccount.setVisibility(View.GONE);
         } else {
+            swNotifications.setChecked(notificationsEnabled);
+
             swNotifications.setVisibility(View.VISIBLE);
             swNotifications.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -142,6 +149,10 @@ public class Profile extends AppCompatActivity {
                                                         "Ilmoitukset sallittu.",
                                                         Toast.LENGTH_LONG
                                                 ).show();
+                                                SharedPreferences sp = getPreferences(Context.MODE_PRIVATE);
+                                                SharedPreferences.Editor editor = sp.edit();
+                                                editor.putBoolean("notification",true);
+                                                editor.apply();
                                             }
 
                                             @Override
@@ -158,9 +169,9 @@ public class Profile extends AppCompatActivity {
                             }
                         });
                     } else {
-                        FirebaseMessaging.getInstance().deleteToken().addOnCompleteListener(new OnCompleteListener<Void>() {
+                        FirebaseMessaging.getInstance().getToken().addOnCompleteListener(new OnCompleteListener<String>() {
                             @Override
-                            public void onComplete(@NonNull Task<Void> task) {
+                            public void onComplete(@NonNull Task<String> task) {
                                 service.deleteTokenFromNotifications(String.format(
                                         "%sRemoveTokenForNotifications?Token=%s",
                                         getResources().getString(R.string.digiruokalista_api_base_url),
@@ -173,6 +184,10 @@ public class Profile extends AppCompatActivity {
                                                 "Ilmoitukset estetty.",
                                                 Toast.LENGTH_LONG
                                         ).show();
+                                        SharedPreferences sp = getPreferences(Context.MODE_PRIVATE);
+                                        SharedPreferences.Editor editor = sp.edit();
+                                        editor.putBoolean("notification",false);
+                                        editor.apply();
                                     }
 
                                     @Override


### PR DESCRIPTION
Yksi ongelma mikä korjaantuu kun sovelluksen poistaa ja aloittaa käytön uudelleen.

Jos notification token on jo palvelimella switchiä ei saa päälle. Eli se on silloin epäsynkassa.

Mutta voin tehdä apille myös tarkastuksen että jos se on jo siellä niin se poistaa sen ja laittaa uudelleen.